### PR TITLE
Make gpg/aptly actually use the specified key

### DIFF
--- a/debian-source/add-deb.sh
+++ b/debian-source/add-deb.sh
@@ -3,7 +3,7 @@
 #
 # To create repo:
 # aptly -config=./.aptly.conf repo create -distribution=stable -component=main -architectures=amd64,i386,armhf,arm64,all yarn
-# aptly -config=./.aptly.conf publish repo -gpg-key=23E7166788B63E1E -architectures=i386,amd64,armhf,arm64,all -origin=yarn -label="yarn-stable" yarn
+# aptly -config=./.aptly.conf publish repo -gpg-key=23E7166788B63E1E! -architectures=i386,amd64,armhf,arm64,all -origin=yarn -label="yarn-stable" yarn
 
 set -ex
 
@@ -23,8 +23,8 @@ rm -rf public/pool/
 # Add the package to the repo and publish the changes. We need to republish
 # *both* stable and rc, due to the removal of the entire pool directory above.
 aptly -config=./.aptly.conf repo add $2 $1
-aptly -config=./.aptly.conf publish update -gpg-key=23E7166788B63E1E stable
-aptly -config=./.aptly.conf publish update -gpg-key=23E7166788B63E1E rc
+aptly -config=./.aptly.conf publish update -gpg-key=23E7166788B63E1E! stable
+aptly -config=./.aptly.conf publish update -gpg-key=23E7166788B63E1E! rc
 
 # Move the public files back to the right place
 mv public/* ../debian/


### PR DESCRIPTION
Without the exclamation point it doesn't take it seriously. See https://github.com/yarnpkg/yarn/issues/6916#issuecomment-454603962 for more details.